### PR TITLE
remove ExpressionAttributeValues if it is an empty object

### DIFF
--- a/src/lib/methods/base-query.ts
+++ b/src/lib/methods/base-query.ts
@@ -49,7 +49,7 @@ export abstract class BaseQuery extends Method {
 		this.params.ExpressionAttributeNames = Object.assign({}, this.params.ExpressionAttributeNames, parsedQuery.ExpressionAttributeNames);
 		this.params.ExpressionAttributeValues = Object.assign({}, this.params.ExpressionAttributeValues, parsedQuery.ExpressionAttributeValues);
 
-		// remove ExpressionAttributeValues if it is an empty object(which will casue a ValidationException error)
+		// Remove ExpressionAttributeValues if it is an empty object(which will casue a ValidationException error)
 		if (JSON.stringify(this.params.ExpressionAttributeValues) === JSON.stringify({})) {
 			delete this.params.ExpressionAttributeValues;
 		}

--- a/src/lib/methods/base-query.ts
+++ b/src/lib/methods/base-query.ts
@@ -49,6 +49,11 @@ export abstract class BaseQuery extends Method {
 		this.params.ExpressionAttributeNames = Object.assign({}, this.params.ExpressionAttributeNames, parsedQuery.ExpressionAttributeNames);
 		this.params.ExpressionAttributeValues = Object.assign({}, this.params.ExpressionAttributeValues, parsedQuery.ExpressionAttributeValues);
 
+		// remove ExpressionAttributeValues if it is an empty object(which will casue a ValidationException error)
+		if (JSON.stringify(this.params.ExpressionAttributeValues) === JSON.stringify({})) {
+			delete this.params.ExpressionAttributeValues;
+		}
+
 		// Return the query so that it can be chained
 		return this;
 	}


### PR DESCRIPTION
When doing query operations, like '$exists',  the query will be parsed into an object with `ExpressionAttributeValues: {}`, which will cause an error ` ValidationException: ExpressionAttributeValues must not be empty`