### PR TITLE
Increase the limit of queries in a transaction to 25 - fixes #67

### DIFF
--- a/src/lib/methods/transactions/read/transact-read.ts
+++ b/src/lib/methods/transactions/read/transact-read.ts
@@ -43,8 +43,8 @@ export class TransactRead extends Method  implements Executable {
 
 		const query = this.buildRawQuery();
 
-		if (query.TransactItems.length > 10) {
-			throw new Error(`Number of transaction items should be less than or equal to \`10\`, got \`${query.TransactItems.length}\``);
+		if (query.TransactItems.length > 25) {
+			throw new Error(`Number of transaction items should be less than or equal to \`25\`, got \`${query.TransactItems.length}\``);
 		}
 
 		const result = await db.transactGetItems(query).promise();

--- a/src/lib/methods/transactions/write/transact-write.ts
+++ b/src/lib/methods/transactions/write/transact-write.ts
@@ -77,8 +77,8 @@ export class TransactWrite extends Method  implements Executable {
 
 		const query = this.buildRawQuery();
 
-		if (query.TransactItems.length > 10) {
-			throw new Error(`Number of transaction items should be less than or equal to \`10\`, got \`${query.TransactItems.length}\``);
+		if (query.TransactItems.length > 25) {
+			throw new Error(`Number of transaction items should be less than or equal to \`25\`, got \`${query.TransactItems.length}\``);
 		}
 
 		await db.transactWriteItems(query).promise();

--- a/src/test/methods/transact-read.ts
+++ b/src/test/methods/transact-read.ts
@@ -45,7 +45,7 @@ test('error if another index is used', async t => {
 	'Can not use a Global Secondary Index in a read transaction');
 });
 
-test('error if number of transaction items is higher than 10', async t => {
+test('error if number of transaction items is higher than 25', async t => {
 	await t.throwsAsync(
 		db.transactRead(
 			db.table('foo').find({id: '1'}),
@@ -59,9 +59,23 @@ test('error if number of transaction items is higher than 10', async t => {
 			db.table('foo').find({id: '9'}),
 			db.table('foo').find({id: '10'}),
 			db.table('foo').find({id: '11'}),
-			db.table('foo').find({id: '12'})
+			db.table('foo').find({id: '12'}),
+			db.table('foo').find({id: '13'}),
+			db.table('foo').find({id: '14'}),
+			db.table('foo').find({id: '15'}),
+			db.table('foo').find({id: '16'}),
+			db.table('foo').find({id: '17'}),
+			db.table('foo').find({id: '18'}),
+			db.table('foo').find({id: '19'}),
+			db.table('foo').find({id: '20'}),
+			db.table('foo').find({id: '21'}),
+			db.table('foo').find({id: '22'}),
+			db.table('foo').find({id: '23'}),
+			db.table('foo').find({id: '24'}),
+			db.table('foo').find({id: '25'}),
+			db.table('foo').find({id: '26'})
 		).exec(),
-	'Number of transaction items should be less than or equal to `10`, got `12`');
+	'Number of transaction items should be less than or equal to `25`, got `26`');
 });
 
 test.serial('execute transactions', async t => {

--- a/src/test/methods/transact-write.ts
+++ b/src/test/methods/transact-write.ts
@@ -26,7 +26,7 @@ test('error if action is not supported', async t => {
 	'Unknown TransactWrite action provided');
 });
 
-test('error if number of transaction items is higher than 10', async t => {
+test('error if number of transaction items is higher than 25', async t => {
 	await t.throwsAsync(
 		db.transactWrite(
 			db.table('foo').insert({id: '1'}, {foo: 'bar'}),
@@ -39,12 +39,27 @@ test('error if number of transaction items is higher than 10', async t => {
 			db.table('foo').insert({id: '8'}, {foo: 'bar'}),
 			db.table('foo').insert({id: '9'}, {foo: 'bar'}),
 			db.table('foo').insert({id: '10'}, {foo: 'bar'}),
-			db.table('foo').insert({id: '11'}, {foo: 'bar'})
+			db.table('foo').insert({id: '11'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '12'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '13'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '14'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '15'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '16'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '17'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '18'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '19'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '20'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '21'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '22'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '23'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '24'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '25'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '26'}, {foo: 'bar'})
 		).exec(),
-	'Number of transaction items should be less than or equal to `10`, got `11`');
+	'Number of transaction items should be less than or equal to `25`, got `26`');
 });
 
-test('error if number of transaction items with conditionals is higher than 10', async t => {
+test('error if number of transaction items with conditionals is higher than 25', async t => {
 	await t.throwsAsync(
 		db.transactWrite(
 			db.table('foo').insert({id: '1'}, {foo: 'bar'}),
@@ -55,12 +70,27 @@ test('error if number of transaction items with conditionals is higher than 10',
 			db.table('foo').insert({id: '6'}, {foo: 'bar'}),
 			db.table('foo').insert({id: '7'}, {foo: 'bar'}),
 			db.table('foo').insert({id: '8'}, {foo: 'bar'}),
-			db.table('foo').insert({id: '9'}, {foo: 'bar'})
+			db.table('foo').insert({id: '9'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '10'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '11'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '12'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '13'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '14'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '15'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '16'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '17'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '18'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '19'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '20'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '21'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '22'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '23'}, {foo: 'bar'}),
+			db.table('foo').insert({id: '24'}, {foo: 'bar'})
 		).withConditions(
 			db.table('bar').find({id: '1'}).where({foo: 10}),
 			db.table('bar').find({id: '2'}).where({foo: 20})
 		).exec(),
-	'Number of transaction items should be less than or equal to `10`, got `11`');
+	'Number of transaction items should be less than or equal to `25`, got `26`');
 });
 
 test('error if condition does not have a where clause', async t => {


### PR DESCRIPTION
> A transaction cannot contain more than 25 unique items.
 https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html#limits-dynamodb-transactions

This PR increases the max limit of the numbers of queries executed by a single transaction.

- Increase limit from `10` to `25`.
- Update tests to reflect this change.