### PR TITLE
Expose all types directly from the root - fixes #71

### DIFF
--- a/src/lib/dynamodb.ts
+++ b/src/lib/dynamodb.ts
@@ -1,14 +1,10 @@
 import AWS from 'aws-sdk';
 import pick from 'object.pick';
 import { Table, TableOptions } from './table';
-import { ListTables } from './methods/list-tables';
-import { Schema } from './types/schema';
-import { DeleteTable } from './methods/delete-table';
-import { CreateTable } from './methods/create-table';
-import { TransactWrite, WriteItem } from './methods/transactions/write/transact-write';
-import { TransactRead, ReadItem } from './methods/transactions/read/transact-read';
+import { ListTables, DeleteTable, CreateTable, TransactWrite, WriteItem, TransactRead, ReadItem } from './methods';
+import { Schema } from './types';
 
-export interface Options {
+export interface DynamoDBOptions {
 	local?: boolean;
 	host?: string;
 	localPort?: number;
@@ -24,9 +20,9 @@ export class DynamoDB {
 
 	public raw?: AWS.DynamoDB;
 	public dynamodb?: AWS.DynamoDB.DocumentClient;
-	private options: Options = {};
+	private options: DynamoDBOptions = {};
 
-	connect(options?: Options) {
+	connect(options?: DynamoDBOptions) {
 		this.options = {
 			prefix: '',
 			prefixDelimiter: '.',

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,3 @@
-import { DynamoDB } from './lib';
-
 export {
 	ReadItem,
 	TransactRead,
@@ -20,12 +18,8 @@ export {
 	Method,
 	Query,
 	Scan,
-	UpdateItem,
-	UpdateQuery,
-	DynamoDBOptions,
-	DynamoDB,
-	TableOptions,
-	Table
-} from './lib';
-
-export default new DynamoDB();
+	UpdateItem
+} from './methods';
+export { UpdateQuery } from './types';
+export { DynamoDBOptions, DynamoDB } from './dynamodb';
+export { TableOptions, Table } from './table';

--- a/src/lib/methods/create-table.ts
+++ b/src/lib/methods/create-table.ts
@@ -1,7 +1,7 @@
 import delay from 'delay';
 import { Method } from './method';
 import { Executable } from './executable';
-import { Schema } from '../types/schema';
+import { Schema } from '../types';
 import { DynamoDB } from '../dynamodb';
 import { Table } from '../table';
 import { CreateTableInput } from 'aws-sdk/clients/dynamodb';
@@ -48,7 +48,7 @@ export class CreateTable extends Method implements Executable {
 	buildRawQuery(): CreateTableInput {
 		return {
 			...this.schema,
-			TableName: (this.table !).name
+			TableName: (this.table!).name
 		};
 	}
 
@@ -92,10 +92,10 @@ export class CreateTable extends Method implements Executable {
 	}
 
 	private async pollHelper() {
-		const db = this.dynamodb.raw !;
+		const db = this.dynamodb.raw!;
 
 		await delay(this.waitMs);
 
-		return await db.describeTable({TableName: (this.table !).name}).promise();
+		return await db.describeTable({TableName: (this.table!).name}).promise();
 	}
 }

--- a/src/lib/methods/index.ts
+++ b/src/lib/methods/index.ts
@@ -1,0 +1,12 @@
+export { ReadItem, TransactRead, TransactQuery, TransactDeleteItem, TransactInsertItem, TransactUpdateItem, WriteItem, TransactWrite, TransactMethod } from './transactions';
+export { BaseQuery } from './base-query';
+export { CreateTable } from './create-table';
+export { DeleteItem } from './delete-item';
+export { DeleteTable } from './delete-table';
+export { Executable } from './executable';
+export { InsertItem } from './insert-item';
+export { ListTables } from './list-tables';
+export { Method } from './method';
+export { Query } from './query';
+export { Scan } from './scan';
+export { UpdateItem } from './update-item';

--- a/src/lib/methods/insert-item.ts
+++ b/src/lib/methods/insert-item.ts
@@ -5,7 +5,7 @@ import { Executable } from './executable';
 import { Method } from './method';
 import { DynamoDB } from '../dynamodb';
 import { Table } from '../table';
-import { UpdateQuery } from '../types/update-query';
+import { UpdateQuery } from '../types';
 
 export class InsertItem extends Method implements Executable {
 
@@ -59,7 +59,7 @@ export class InsertItem extends Method implements Executable {
 
 		const result = {
 			...this.params,
-			TableName: (this.table !).name,
+			TableName: (this.table!).name,
 			ConditionExpression: `NOT (${parsedQuery.ConditionExpression})`,
 			ExpressionAttributeNames: {...this.params.ExpressionAttributeNames, ...parsedQuery.ExpressionAttributeNames},
 			ExpressionAttributeValues: {...this.params.ExpressionAttributeValues, ...parsedQuery.ExpressionAttributeValues}

--- a/src/lib/methods/method.ts
+++ b/src/lib/methods/method.ts
@@ -1,6 +1,6 @@
 import { DynamoDB } from '../dynamodb';
 import { Table } from '../table';
-import { Params } from '../types/params';
+import { Params } from '../types';
 import { QueryBuilder } from '../types/query-builder';
 
 export abstract class Method implements QueryBuilder {
@@ -10,7 +10,7 @@ export abstract class Method implements QueryBuilder {
 	constructor(
 		protected readonly table: Table | null,
 		protected readonly dynamodb: DynamoDB
-	) { }
+	) {}
 
 	/**
 	 * Builds and returns the raw DynamoDB query object.

--- a/src/lib/methods/transactions/index.ts
+++ b/src/lib/methods/transactions/index.ts
@@ -1,0 +1,3 @@
+export { ReadItem, TransactRead, TransactQuery } from './read';
+export { TransactDeleteItem, TransactInsertItem, TransactUpdateItem, WriteItem, TransactWrite } from './write';
+export { TransactMethod } from './transact-method';

--- a/src/lib/methods/transactions/read/index.ts
+++ b/src/lib/methods/transactions/read/index.ts
@@ -1,0 +1,2 @@
+export { ReadItem, TransactRead } from './transact-read';
+export { TransactQuery } from './transact-query';

--- a/src/lib/methods/transactions/write/index.ts
+++ b/src/lib/methods/transactions/write/index.ts
@@ -1,0 +1,4 @@
+export { TransactDeleteItem } from './transact-delete-item';
+export { TransactInsertItem } from './transact-insert-item';
+export { TransactUpdateItem } from './transact-update-item';
+export { WriteItem, TransactWrite } from './transact-write';

--- a/src/lib/table.ts
+++ b/src/lib/table.ts
@@ -1,15 +1,8 @@
 import { DynamoDB } from './dynamodb';
-import { Query } from './methods/query';
-import { Scan } from './methods/scan';
-import { InsertItem } from './methods/insert-item';
-import { UpdateItem } from './methods/update-item';
-import { DeleteItem } from './methods/delete-item';
-import { DeleteTable } from './methods/delete-table';
-import { CreateTable } from './methods/create-table';
+import { Query, Scan, InsertItem, UpdateItem, DeleteItem, DeleteTable, CreateTable } from './methods';
 import * as table from './utils/table';
 import { operators as updateOperators } from './utils/update';
-import { Map } from './types/map';
-import { Schema } from './types/schema';
+import { Map, Schema } from './types';
 
 export interface TableOptions {
 	raw?: boolean;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,0 +1,5 @@
+export { Map } from './map';
+export { Params } from './params';
+export { QueryBuilder } from './query-builder';
+export { Schema } from './schema';
+export { UpdateQuery } from './update-query';

--- a/src/lib/utils/name.ts
+++ b/src/lib/utils/name.ts
@@ -1,11 +1,11 @@
-import { Map } from '../types/map';
+import { Map } from '../types';
 
-export interface KeyNameResult {
+interface KeyNameResult {
 	Expression: string;
 	ExpressionAttributeNames: Map<string>;
 }
 
-export interface ValueNameResult {
+interface ValueNameResult {
 	Expression: string | string[];
 	ExpressionAttributeValues: Map<any>;
 }

--- a/src/lib/utils/query.ts
+++ b/src/lib/utils/query.ts
@@ -1,8 +1,8 @@
 import isObject from 'is-object';
 import * as nameUtil from './name';
-import { Map } from '../types/map';
+import { Map } from '../types';
 
-export interface ParseResult {
+interface ParseResult {
 	ConditionExpression: string;
 	ExpressionAttributeNames: Map<string>;
 	ExpressionAttributeValues: Map<any>;

--- a/src/lib/utils/update.ts
+++ b/src/lib/utils/update.ts
@@ -1,8 +1,7 @@
 import * as nameUtil from './name';
-import { UpdateQuery } from '../types/update-query';
-import { Map } from '../types/map';
+import { UpdateQuery, Map } from '../types';
 
-export interface ParseResult {
+interface ParseResult {
 	UpdateExpression: string;
 	ExpressionAttributeNames: Map<string>;
 	ExpressionAttributeValues: Map<any>;
@@ -20,7 +19,7 @@ export function parse(query: UpdateQuery): ParseResult {
 		expr.set = expr.set || [];
 
 		expr.set = expr.set.concat(Object.keys(query.$set).map(key => {
-			const value = (query.$set !)[key];
+			const value = (query.$set!)[key];
 
 			const k = nameUtil.generateKeyName(key);
 			const v = nameUtil.generateValueName(key, value, values, true);
@@ -46,7 +45,7 @@ export function parse(query: UpdateQuery): ParseResult {
 		expr.set = expr.set || [];
 
 		expr.set = expr.set.concat(Object.keys(query.$inc).map(key => {
-			const value = (query.$inc !)[key];
+			const value = (query.$inc!)[key];
 
 			const k = nameUtil.generateKeyName(key);
 			const v = nameUtil.generateValueName(key, value, values);
@@ -64,7 +63,7 @@ export function parse(query: UpdateQuery): ParseResult {
 		const operator = query.$push ? '$push' : '$unshift';
 
 		expr.set = expr.set.concat(Object.keys(query[operator] || {}).map(key => {
-			let value = (query[operator] !)[key];
+			let value = (query[operator]!)[key];
 
 			if (value.$each) {
 				value = value.$each;

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import db = require('../');
+import db from '..';
 
 test.before(() => {
 	db.connect();
@@ -25,10 +25,10 @@ test('connect options', t => {
 
 test('connect locally', t => {
 	db.connect({local: true});
-	t.is((db.raw !).endpoint.href, 'http://localhost:8000/');
+	t.is((db.raw!).endpoint.href, 'http://localhost:8000/');
 
 	db.connect({local: true, localPort: 9000});
-	t.is((db.raw !).endpoint.href, 'http://localhost:9000/');
+	t.is((db.raw!).endpoint.href, 'http://localhost:9000/');
 });
 
 test('table', t => {


### PR DESCRIPTION
I've exported every thing through a barrel file in the specific folder. I opted to not use `export * from  './file'` to avoid naming collisions.

But by doing this I've actually found a naming collision in the types, the top `ParseResult` is exported in both `src/lib/utils/query.ts` and `src/lib/utils/update.ts`.

Since the types are not equal I am not sure what to do.