### PR TITLE
feat: $addToSet

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -194,12 +194,21 @@ Employee.update({Organisation: 'Amazon', Email: 'foo.bar@amazon.com'}, {$set: {T
 	});
 ```
 
+Or, if working with [Sets](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.SetTypes) you can use `$addToSet` to add unique values to a Set, it supports single value, arrays and `$each` operator.
+
+```js
+Employee.update({Organisation: 'Amazon', Email: 'foo.bar@amazon.com'}, {$addToSet: {Departments: ['IT', 'IT']}}).exec()
+	.then(employee => {
+		// => {FirstName: 'Foo', Name: 'Bar', Salary: 4650, Title: 'CTO', Organisation: 'Amazon', Email: 'foo.bar@amazon.com', Hobby: ['cycling', 'swimming', 'walking'], Departments: ['IT]}
+	});
+```
+
 You can use `$unshift` to prepend a list with one or multiple values.
 
 ```js
-Employee.update({Organisation: 'Amazon', Email: 'foo.bar@amazon.com'}, {$unshift: {Hobby: 'programming'}}}).exec()
+Employee.update({Organisation: 'Amazon', Email: 'foo.bar@amazon.com'}, {$unshift: {Hobby: 'programming'}}).exec()
 	.then(employee => {
-		// => {FirstName: 'Foo', Name: 'Bar', Salary: 4650, Title: 'CTO', Organisation: 'Amazon', Email: 'foo.bar@amazon.com', Hobby: ['programming', 'cycling', 'swimming', 'walking']}
+		// => {FirstName: 'Foo', Name: 'Bar', Salary: 4650, Title: 'CTO', Organisation: 'Amazon', Email: 'foo.bar@amazon.com', Hobby: ['programming', 'cycling', 'swimming', 'walking'], Departments: ['IT]}
 	});
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -199,7 +199,7 @@ Or, if working with [Sets](https://docs.aws.amazon.com/amazondynamodb/latest/dev
 ```js
 Employee.update({Organisation: 'Amazon', Email: 'foo.bar@amazon.com'}, {$addToSet: {Departments: ['IT', 'IT']}}).exec()
 	.then(employee => {
-		// => {FirstName: 'Foo', Name: 'Bar', Salary: 4650, Title: 'CTO', Organisation: 'Amazon', Email: 'foo.bar@amazon.com', Hobby: ['cycling', 'swimming', 'walking'], Departments: ['IT]}
+		// => {FirstName: 'Foo', Name: 'Bar', Salary: 4650, Title: 'CTO', Organisation: 'Amazon', Email: 'foo.bar@amazon.com', Hobby: ['cycling', 'swimming', 'walking'], Departments: ['IT']}
 	});
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -208,7 +208,7 @@ You can use `$unshift` to prepend a list with one or multiple values.
 ```js
 Employee.update({Organisation: 'Amazon', Email: 'foo.bar@amazon.com'}, {$unshift: {Hobby: 'programming'}}).exec()
 	.then(employee => {
-		// => {FirstName: 'Foo', Name: 'Bar', Salary: 4650, Title: 'CTO', Organisation: 'Amazon', Email: 'foo.bar@amazon.com', Hobby: ['programming', 'cycling', 'swimming', 'walking'], Departments: ['IT]}
+		// => {FirstName: 'Foo', Name: 'Bar', Salary: 4650, Title: 'CTO', Organisation: 'Amazon', Email: 'foo.bar@amazon.com', Hobby: ['programming', 'cycling', 'swimming', 'walking'], Departments: ['IT']}
 	});
 ```
 

--- a/src/lib/types/update-query.ts
+++ b/src/lib/types/update-query.ts
@@ -1,7 +1,8 @@
 export interface UpdateQuery {
-	$set?: {[key: string]: any};
-	$unset?: {[key: string]: any};
-	$inc?: {[key: string]: any};
-	$push?: {[key: string]: any};
-	$unshift?: {[key: string]: any};
+	$set?: { [key: string]: any };
+	$unset?: { [key: string]: any };
+	$inc?: { [key: string]: any };
+	$push?: { [key: string]: any };
+	$unshift?: { [key: string]: any };
+	$addToSet?: { [key: string]: any };
 }

--- a/src/lib/utils/update.ts
+++ b/src/lib/utils/update.ts
@@ -1,8 +1,6 @@
-import AWS from 'aws-sdk';
+import DynamoDBSet from 'aws-sdk/lib/dynamodb/set';
 import { Map, UpdateQuery } from '../types';
 import * as nameUtil from './name';
-
-const db = new AWS.DynamoDB.DocumentClient();
 
 interface ParseResult {
 	UpdateExpression: string;
@@ -101,8 +99,9 @@ export function parse(query: UpdateQuery): ParseResult {
 
 		expr.add = expr.add.concat(Object.keys(query.$addToSet).map(key => {
 			const value = fromArrayEach((query.$addToSet!)[key]);
+			const dynamoDBSet = new DynamoDBSet(value);
 			const k = nameUtil.generateKeyName(key);
-			const v = nameUtil.generateValueName(key, db.createSet(value), values, true);
+			const v = nameUtil.generateValueName(key, dynamoDBSet, values, true);
 
 			Object.assign(names, k.ExpressionAttributeNames);
 			Object.assign(values, v.ExpressionAttributeValues);

--- a/src/lib/utils/update.ts
+++ b/src/lib/utils/update.ts
@@ -76,7 +76,7 @@ export function parse(query: UpdateQuery): ParseResult {
 
 		const operator = query.$push ? '$push' : '$unshift';
 
-		expr.set = expr.set.concat(Object.keys(query[operator] || {}).map(key => {
+		expr.set = expr.set.concat(Object.keys(query[operator]!).map(key => {
 			const value = fromArrayEach((query[operator]!)[key]);
 			const k = nameUtil.generateKeyName(key);
 			const v = nameUtil.generateValueName(key, value, values, true);
@@ -99,7 +99,7 @@ export function parse(query: UpdateQuery): ParseResult {
 	if (query.$addToSet) {
 		expr.add = expr.add || [];
 
-		expr.add = expr.add.concat(Object.keys(query.$addToSet || {}).map(key => {
+		expr.add = expr.add.concat(Object.keys(query.$addToSet).map(key => {
 			const value = fromArrayEach((query.$addToSet!)[key]);
 			const k = nameUtil.generateKeyName(key);
 			const v = nameUtil.generateValueName(key, db.createSet(value), values, true);

--- a/src/lib/utils/update.ts
+++ b/src/lib/utils/update.ts
@@ -15,9 +15,10 @@ const fromArrayEach = (value) => {
 		if (!Array.isArray(value.$each)) {
 			throw new Error('The value for $each should be an array.');
 		}
-		return value.$each;
 
+		return value.$each;
 	}
+
 	return [value];
 };
 

--- a/src/test/methods/update.ts
+++ b/src/test/methods/update.ts
@@ -1,5 +1,4 @@
 import test from 'ava';
-import DynamoDBSet from 'aws-sdk/lib/dynamodb/set';
 import sinon from 'sinon';
 import db from '../..';
 import {
@@ -152,7 +151,7 @@ test.serial('multi key update ADD and SET', async t => {
 			':v_foo': 'bar',
 			':v_id': '5',
 			':v_email': 'foo@bar.com',
-			':v_friends': new DynamoDBSet(['bar@bar.com'])
+			':v_friends': db.dynamodb?.createSet(['bar@bar.com'])
 		},
 		ConditionExpression: '#k_id=:v_id AND #k_email=:v_email'
 	});

--- a/src/test/methods/update.ts
+++ b/src/test/methods/update.ts
@@ -1,4 +1,5 @@
 import test from 'ava';
+import DynamoDBSet from 'aws-sdk/lib/dynamodb/set';
 import sinon from 'sinon';
 import db from '../..';
 import {
@@ -151,7 +152,7 @@ test.serial('multi key update ADD and SET', async t => {
 			':v_foo': 'bar',
 			':v_id': '5',
 			':v_email': 'foo@bar.com',
-			':v_friends': db.dynamodb?.createSet(['bar@bar.com'])
+			':v_friends': new DynamoDBSet(['bar@bar.com'])
 		},
 		ConditionExpression: '#k_id=:v_id AND #k_email=:v_email'
 	});

--- a/src/test/utils/update.ts
+++ b/src/test/utils/update.ts
@@ -84,6 +84,17 @@ test('$addToSet $each in array', t => {
 	t.deepEqual(result.ExpressionAttributeValues, {':v_friends': db.createSet(['mario', 'luigi'])});
 });
 
+test('$addToSet (double)', t => {
+	const result = update.parse({$addToSet: {friends: {$each: ['mario', 'luigi']}, enemies: 'bowser'}});
+
+	t.is(result.UpdateExpression, 'ADD #k_friends :v_friends, #k_enemies :v_enemies');
+	t.deepEqual(result.ExpressionAttributeNames, {'#k_friends': 'friends', '#k_enemies': 'enemies'});
+	t.deepEqual(result.ExpressionAttributeValues, {
+		':v_friends': db.createSet(['mario', 'luigi']),
+		':v_enemies': db.createSet(['bowser'])
+	});
+});
+
 test('$unshift $each in array', t => {
 	const result = update.parse({$unshift: {scores: {$each: [85, 94]}}});
 

--- a/src/test/utils/update.ts
+++ b/src/test/utils/update.ts
@@ -60,6 +60,14 @@ test('$push array', t => {
 	t.deepEqual(result.ExpressionAttributeValues, {':v_scores': [[85, 94]], ':_v_empty_list': []});
 });
 
+test('$addToSet array', t => {
+	const result = update.parse({$addToSet: {friends: ['mario', 'luigi']}});
+
+	t.is(result.UpdateExpression, 'ADD #k_friends :v_friends');
+	t.deepEqual(result.ExpressionAttributeNames, {'#k_friends': 'friends'});
+	t.deepEqual(result.ExpressionAttributeValues, {':v_friends': db.createSet(['mario', 'luigi'])});
+});
+
 test('$unshift array', t => {
 	const result = update.parse({$unshift: {scores: [85, 94]}});
 

--- a/src/test/utils/update.ts
+++ b/src/test/utils/update.ts
@@ -1,8 +1,6 @@
 import test from 'ava';
-import AWS from 'aws-sdk';
+import DynamoDBSet from 'aws-sdk/lib/dynamodb/set';
 import * as update from '../../lib/utils/update';
-
-const db = new AWS.DynamoDB.DocumentClient();
 
 test('$set', t => {
 	const result = update.parse({$set: {id: 5, description: 'foo'}});
@@ -41,7 +39,7 @@ test('$addToSet', t => {
 
 	t.is(result.UpdateExpression, 'ADD #k_friends :v_friends');
 	t.deepEqual(result.ExpressionAttributeNames, {'#k_friends': 'friends'});
-	t.deepEqual(result.ExpressionAttributeValues, {':v_friends': db.createSet(['mario'])});
+	t.deepEqual(result.ExpressionAttributeValues, {':v_friends': new DynamoDBSet(['mario'])});
 });
 
 test('$unshift', t => {
@@ -81,7 +79,7 @@ test('$addToSet $each in array', t => {
 
 	t.is(result.UpdateExpression, 'ADD #k_friends :v_friends');
 	t.deepEqual(result.ExpressionAttributeNames, {'#k_friends': 'friends'});
-	t.deepEqual(result.ExpressionAttributeValues, {':v_friends': db.createSet(['mario', 'luigi'])});
+	t.deepEqual(result.ExpressionAttributeValues, {':v_friends': new DynamoDBSet(['mario', 'luigi'])});
 });
 
 test('$addToSet (double)', t => {
@@ -90,8 +88,8 @@ test('$addToSet (double)', t => {
 	t.is(result.UpdateExpression, 'ADD #k_friends :v_friends, #k_enemies :v_enemies');
 	t.deepEqual(result.ExpressionAttributeNames, {'#k_friends': 'friends', '#k_enemies': 'enemies'});
 	t.deepEqual(result.ExpressionAttributeValues, {
-		':v_friends': db.createSet(['mario', 'luigi']),
-		':v_enemies': db.createSet(['bowser'])
+		':v_friends': new DynamoDBSet(['mario', 'luigi']),
+		':v_enemies': new DynamoDBSet(['bowser'])
 	});
 });
 

--- a/src/test/utils/update.ts
+++ b/src/test/utils/update.ts
@@ -1,6 +1,8 @@
 import test from 'ava';
-import DynamoDBSet from 'aws-sdk/lib/dynamodb/set';
+import AWS from 'aws-sdk';
 import * as update from '../../lib/utils/update';
+
+const db = new AWS.DynamoDB.DocumentClient();
 
 test('$set', t => {
 	const result = update.parse({$set: {id: 5, description: 'foo'}});
@@ -39,7 +41,7 @@ test('$addToSet', t => {
 
 	t.is(result.UpdateExpression, 'ADD #k_friends :v_friends');
 	t.deepEqual(result.ExpressionAttributeNames, {'#k_friends': 'friends'});
-	t.deepEqual(result.ExpressionAttributeValues, {':v_friends': new DynamoDBSet(['mario'])});
+	t.deepEqual(result.ExpressionAttributeValues, {':v_friends': db.createSet(['mario'])});
 });
 
 test('$unshift', t => {
@@ -79,7 +81,7 @@ test('$addToSet $each in array', t => {
 
 	t.is(result.UpdateExpression, 'ADD #k_friends :v_friends');
 	t.deepEqual(result.ExpressionAttributeNames, {'#k_friends': 'friends'});
-	t.deepEqual(result.ExpressionAttributeValues, {':v_friends': new DynamoDBSet(['mario', 'luigi'])});
+	t.deepEqual(result.ExpressionAttributeValues, {':v_friends': db.createSet(['mario', 'luigi'])});
 });
 
 test('$addToSet (double)', t => {
@@ -88,8 +90,8 @@ test('$addToSet (double)', t => {
 	t.is(result.UpdateExpression, 'ADD #k_friends :v_friends, #k_enemies :v_enemies');
 	t.deepEqual(result.ExpressionAttributeNames, {'#k_friends': 'friends', '#k_enemies': 'enemies'});
 	t.deepEqual(result.ExpressionAttributeValues, {
-		':v_friends': new DynamoDBSet(['mario', 'luigi']),
-		':v_enemies': new DynamoDBSet(['bowser'])
+		':v_friends': db.createSet(['mario', 'luigi']),
+		':v_enemies': db.createSet(['bowser'])
 	});
 });
 

--- a/src/test/utils/update.ts
+++ b/src/test/utils/update.ts
@@ -1,5 +1,8 @@
 import test from 'ava';
+import AWS from 'aws-sdk';
 import * as update from '../../lib/utils/update';
+
+const db = new AWS.DynamoDB.DocumentClient();
 
 test('$set', t => {
 	const result = update.parse({$set: {id: 5, description: 'foo'}});
@@ -33,6 +36,14 @@ test('$push', t => {
 	t.deepEqual(result.ExpressionAttributeValues, {':v_scores': [85], ':_v_empty_list': []});
 });
 
+test('$addToSet', t => {
+	const result = update.parse({$addToSet: {friends: 'mario'}});
+
+	t.is(result.UpdateExpression, 'ADD #k_friends :v_friends');
+	t.deepEqual(result.ExpressionAttributeNames, {'#k_friends': 'friends'});
+	t.deepEqual(result.ExpressionAttributeValues, {':v_friends': db.createSet(['mario'])});
+});
+
 test('$unshift', t => {
 	const result = update.parse({$unshift: {scores: 85}});
 
@@ -63,6 +74,14 @@ test('$push $each in array', t => {
 	t.is(result.UpdateExpression, 'SET #k_scores=list_append(if_not_exists(#k_scores, :_v_empty_list), :v_scores)');
 	t.deepEqual(result.ExpressionAttributeNames, {'#k_scores': 'scores'});
 	t.deepEqual(result.ExpressionAttributeValues, {':v_scores': [85, 94], ':_v_empty_list': []});
+});
+
+test('$addToSet $each in array', t => {
+	const result = update.parse({$addToSet: {friends: {$each: ['mario', 'luigi']}}});
+
+	t.is(result.UpdateExpression, 'ADD #k_friends :v_friends');
+	t.deepEqual(result.ExpressionAttributeNames, {'#k_friends': 'friends'});
+	t.deepEqual(result.ExpressionAttributeValues, {':v_friends': db.createSet(['mario', 'luigi'])});
 });
 
 test('$unshift $each in array', t => {


### PR DESCRIPTION
`ADD key value` to Sets


https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.ADD.Set

Even though $removeFromSet is not a MongoDB operator I would implement that because dynamodb has this option. Or maybe use $pull for that (only works for sets, not arrays)