### PR TITLE
feat: Add $ifNotExists tot $set operator

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -176,9 +176,9 @@ Employee.find({Organisation: 'Amazon'}).where({Salary: {$gt: 3000}}).count().exe
 #### insert
 
 ```js
-Employee.insert({Organisation: 'Amazon', Email: 'foo.bar@amazon.com'}, {Title: 'CFO', FirstName: 'Foo', Name: 'Bar', Salary: 4500}).exec()
+Employee.insert({Organisation: 'Amazon', Email: 'foo.bar@amazon.com'}, {Title: 'CFO', HiredAt: 'last year', FirstName: 'Foo', Name: 'Bar', Salary: 4500}).exec()
 	.then(employee => {
-		// => {FirstName: 'Foo', Name: 'Bar', Salary: 4500, Title: 'CFO', Organisation: 'Amazon', Email: 'foo.bar@amazon.com'}
+		// => {FirstName: 'Foo', Name: 'Bar', Salary: 4500, Title: 'CFO', HiredAt: 'last year', Organisation: 'Amazon', Email: 'foo.bar@amazon.com'}
 	});
 ```
 
@@ -187,10 +187,12 @@ Employee.insert({Organisation: 'Amazon', Email: 'foo.bar@amazon.com'}, {Title: '
 The first parameter in the `update` method is the primary key (hash + range) and the second method is a query that
 defines the updates of the fields.
 
+You can use `$set: { field: { $ifNotExists: value } }` to only set the value if the field does not exists on the record
+
 ```js
-Employee.update({Organisation: 'Amazon', Email: 'foo.bar@amazon.com'}, {$set: {Title: 'CTO'}, $inc: {Salary: 150}, $push: {Hobby: {$each: ['swimming', 'walking']}}}).exec()
+Employee.update({Organisation: 'Amazon', Email: 'foo.bar@amazon.com'}, {$set: {Title: 'CTO', HiredAt: {$ifNotExists: 'today'}}, $inc: {Salary: 150}, $push: {Hobby: {$each: ['swimming', 'walking']}}}).exec()
 	.then(employee => {
-		// => {FirstName: 'Foo', Name: 'Bar', Salary: 4650, Title: 'CTO', Organisation: 'Amazon', Email: 'foo.bar@amazon.com', Hobby: ['cycling', 'swimming', 'walking']}
+		// => {FirstName: 'Foo', Name: 'Bar', Salary: 4650, Title: 'CTO', HiredAt: 'last year', Organisation: 'Amazon', Email: 'foo.bar@amazon.com', Hobby: ['cycling', 'swimming', 'walking']}
 	});
 ```
 

--- a/src/lib/methods/base-query.ts
+++ b/src/lib/methods/base-query.ts
@@ -1,7 +1,7 @@
-import * as queryUtil from '../utils/query';
-import { Method } from './method';
 import { DynamoDB } from '../dynamodb';
 import { Table } from '../table';
+import * as queryUtil from '../utils/query';
+import { Method } from './method';
 
 export abstract class BaseQuery extends Method {
 
@@ -42,6 +42,10 @@ export abstract class BaseQuery extends Method {
 	 * @param	query			The query to filter the records on.
 	 */
 	where(query: any) {
+		if (!query) {
+			return this;
+		}
+
 		// Parse the query
 		const parsedQuery = queryUtil.parse(query, this.params.ExpressionAttributeValues);
 

--- a/src/lib/methods/delete-item.ts
+++ b/src/lib/methods/delete-item.ts
@@ -38,6 +38,10 @@ export class DeleteItem extends Method implements Executable {
 	 * @param	condition		A condition that must be satisfied in order for a conditional DeleteItem to succeed.
 	 */
 	where(condition: any) {
+		if (!condition) {
+			return this;
+		}
+
 		// Parse the query
 		const parsedQuery = queryUtil.parse(condition, this.params.ExpressionAttributeValues);
 

--- a/src/lib/methods/update-item.ts
+++ b/src/lib/methods/update-item.ts
@@ -1,9 +1,9 @@
 import { UpdateItemInput } from 'aws-sdk/clients/dynamodb';
-import * as queryUtil from '../utils/query';
-import { InsertItem } from './insert-item';
-import { Executable } from './executable';
 import { DynamoDB } from '../dynamodb';
 import { Table } from '../table';
+import * as queryUtil from '../utils/query';
+import { Executable } from './executable';
+import { InsertItem } from './insert-item';
 
 export class UpdateItem extends InsertItem implements Executable {
 
@@ -18,6 +18,10 @@ export class UpdateItem extends InsertItem implements Executable {
 	 * @param	condition           A condition that must be satisfied in order for a conditional UpdateItem to succeed.
 	 */
 	where(condition: any) {
+		if (!condition) {
+			return this;
+		}
+
 		// Parse the query
 		const parsedQuery = queryUtil.parse(condition, this.params.ExpressionAttributeValues);
 

--- a/src/lib/types/update-query.ts
+++ b/src/lib/types/update-query.ts
@@ -1,5 +1,5 @@
 export interface UpdateQuery {
-	$set?: { [key: string]: any };
+	$set?: { [key: string]: { $ifNotExists: any } | any };
 	$unset?: { [key: string]: any };
 	$inc?: { [key: string]: any };
 	$push?: { [key: string]: any };

--- a/src/lib/utils/update.ts
+++ b/src/lib/utils/update.ts
@@ -37,6 +37,15 @@ export function parse(query: UpdateQuery): ParseResult {
 
 		expr.set = expr.set.concat(Object.keys(query.$set).map(key => {
 			const value = (query.$set!)[key];
+			if (value?.$ifNotExists) {
+				const k = nameUtil.generateKeyName(key);
+				const v = nameUtil.generateValueName(key, value.$ifNotExists, values, true);
+
+				Object.assign(names, k.ExpressionAttributeNames);
+				Object.assign(values, v.ExpressionAttributeValues);
+
+				return k.Expression + '=if_not_exists(' + k.Expression + ', ' + v.Expression + ')';
+			}
 
 			const k = nameUtil.generateKeyName(key);
 			const v = nameUtil.generateValueName(key, value, values, true);

--- a/src/test/methods/delete.ts
+++ b/src/test/methods/delete.ts
@@ -1,8 +1,12 @@
 import test from 'ava';
 import sinon from 'sinon';
-import stubPromise from '../fixtures/stub-promise';
 import db from '../..';
-import { serviceUnavailableException, conditionalCheckFailedException, throttlingException } from '../fixtures/aws-error';
+import {
+	conditionalCheckFailedException,
+	serviceUnavailableException,
+	throttlingException
+} from '../fixtures/aws-error';
+import stubPromise from '../fixtures/stub-promise';
 
 db.connect({prefix: 'delete'});
 
@@ -81,6 +85,17 @@ test.serial('delete', async t => {
 
 test.serial('result', async t => {
 	t.falsy(await Table.remove({id: '5'}).exec());
+});
+
+test.serial('undefined where', async t => {
+	await Table.remove({id: '5'}).where(undefined).exec();
+
+	t.deepEqual(deleteStub.lastCall.args[0], {
+		TableName: 'delete.Table',
+		Key: {
+			id: '5'
+		}
+	});
 });
 
 test.serial('where', async t => {

--- a/src/test/methods/find.ts
+++ b/src/test/methods/find.ts
@@ -1,8 +1,12 @@
 import test from 'ava';
 import sinon from 'sinon';
-import stubPromise from '../fixtures/stub-promise';
 import db from '../..';
-import { serviceUnavailableException, throttlingException, conditionalCheckFailedException } from '../fixtures/aws-error';
+import {
+	conditionalCheckFailedException,
+	serviceUnavailableException,
+	throttlingException
+} from '../fixtures/aws-error';
+import stubPromise from '../fixtures/stub-promise';
 
 db.connect();
 
@@ -177,6 +181,10 @@ test.serial('count', async t => {
 	t.is(await Table.find({id: '5'}).count().exec(), 2);
 });
 
+test.serial('find with undefined where', async t => {
+	t.is(await Table.find({id: '5'}).where(undefined).count().exec(), 2);
+});
+
 test.serial('count with no result', async t => {
 	t.is(await Table.find({foo: 'bar'}).count().exec(), 0);
 });
@@ -195,6 +203,22 @@ test.serial('select undefined', async t => {
 			':v_foo': 'bar'
 		},
 		Select: 'COUNT'
+	});
+});
+
+test.serial('undefined where', async t => {
+	await Table.find({foo: 'bar'}).where(undefined).exec();
+
+	t.deepEqual(queryStub.lastCall.args[0], {
+		TableName: 'Table',
+		ConsistentRead: false,
+		KeyConditionExpression: '#k_foo=:v_foo',
+		ExpressionAttributeNames: {
+			'#k_foo': 'foo'
+		},
+		ExpressionAttributeValues: {
+			':v_foo': 'bar'
+		}
 	});
 });
 

--- a/src/test/methods/update.ts
+++ b/src/test/methods/update.ts
@@ -102,6 +102,30 @@ test.serial('single key update', async t => {
 	});
 });
 
+test.serial('single key update if not exists', async t => {
+	await Table.update({id: '5'}, {$set: {foo: {$ifNotExists: 'foo'}, bar: 'bar'}}).exec();
+
+	t.deepEqual(updateStub.lastCall.args[0], {
+		TableName: 'Table',
+		ReturnValues: 'ALL_NEW',
+		Key: {
+			id: '5'
+		},
+		UpdateExpression: 'SET #k_foo=if_not_exists(#k_foo, :v_foo), #k_bar=:v_bar',
+		ExpressionAttributeNames: {
+			'#k_bar': 'bar',
+			'#k_foo': 'foo',
+			'#k_id': 'id'
+		},
+		ExpressionAttributeValues: {
+			':v_bar': 'bar',
+			':v_foo': 'foo',
+			':v_id': '5'
+		},
+		ConditionExpression: '#k_id=:v_id'
+	});
+});
+
 test.serial('multi key update', async t => {
 	await Table.update({id: '5', email: 'foo@bar.com'}, {$set: {foo: 'bar'}}).exec();
 

--- a/src/test/methods/update.ts
+++ b/src/test/methods/update.ts
@@ -181,6 +181,31 @@ test.serial('multi key update ADD and SET', async t => {
 	});
 });
 
+test.serial('undefined where', async t => {
+	await Table.update({id: '5'}, {$set: {foo: 'bar'}, $inc: {salary: 1000}}).where(undefined).exec();
+
+	t.deepEqual(updateStub.lastCall.args[0], {
+		TableName: 'Table',
+		ReturnValues: 'ALL_NEW',
+		Key: {
+			id: '5'
+		},
+		UpdateExpression: 'SET #k_foo=:v_foo, #k_salary=if_not_exists(#k_salary, :_v_empty_value)+:v_salary',
+		ExpressionAttributeNames: {
+			'#k_foo': 'foo',
+			'#k_salary': 'salary',
+			'#k_id': 'id'
+		},
+		ExpressionAttributeValues: {
+			':_v_empty_value': 0,
+			':v_foo': 'bar',
+			':v_salary': 1000,
+			':v_id': '5'
+		},
+		ConditionExpression: '#k_id=:v_id'
+	});
+});
+
 test.serial('where', async t => {
 	await Table.update({id: '5'}, {$set: {foo: 'bar'}, $inc: {salary: 1000}}).where({email: 'foo@bar.com'}).exec();
 

--- a/src/test/utils/update.ts
+++ b/src/test/utils/update.ts
@@ -12,6 +12,14 @@ test('$set', t => {
 	t.deepEqual(result.ExpressionAttributeValues, {':v_id': 5, ':v_description': 'foo'});
 });
 
+test('$set $ifNotExists', t => {
+	const result = update.parse({$set: {id: 5, description: {$ifNotExists: 'foo'}}});
+
+	t.is(result.UpdateExpression, 'SET #k_id=:v_id, #k_description=if_not_exists(#k_description, :v_description)');
+	t.deepEqual(result.ExpressionAttributeNames, {'#k_id': 'id', '#k_description': 'description'});
+	t.deepEqual(result.ExpressionAttributeValues, {':v_id': 5, ':v_description': 'foo'});
+});
+
 test('$unset', t => {
 	const result = update.parse({$unset: {description: true}});
 


### PR DESCRIPTION
Allow to set a value only if it does not exists on the record, a good use case is on upsert and setting a `createdAt` property

```js
{ $set:  { createdAt: { $ifNotExists: date() } } }
```

https://docs.amazonaws.cn/en_us/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.SET.PreventingAttributeOverwrites


extra: allow undefined/null where clause (to be ignored)