### PR TITLE
Add support for the AWS SDK internal retry logic

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,19 @@ db.connect({
 })
 ```
 
+As an alternative, the internal retry behaviour of the AWS SDK can also be used by setting [`maxRetries`](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#maxRetries-property) and [`retryDelayOptions`](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#retryDelayOptions-property).
+
+```js
+db.connect({
+	maxRetries: 3,
+	retryDelayOptions: { base: 300 }
+})
+```
+
+As this setting is global, it cannot be overridden at the method level.
+
+Note that it may not advisable to use both `dynongo`'s retry logic and enable the AWS SDK retry behaviour at the same time. If both are enabled, the AWS SDK retry behaviour will trigger first and if the failure persists, the built-in logic inside `dynongo` will keep retrying the failing method.
+
 #### DynamoDB Local
 
 It is possible to connect to a [local DynamoDB](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tools.DynamoDBLocal.html) database

--- a/src/lib/dynamodb.ts
+++ b/src/lib/dynamodb.ts
@@ -27,6 +27,11 @@ export interface DynamoDBOptions {
 	sessionToken?: string;
 	retries?: number | RetryOptions;
 	httpOptions?: AWS.HTTPOptions;
+	maxRetries?: number;
+	retryDelayOptions?: {
+		base?: number,
+		customBackoff?(retryCount: number, err: Error): number
+	};
 }
 
 export class DynamoDB {
@@ -47,7 +52,14 @@ export class DynamoDB {
 
 		this._retries = configureRetryOptions(this.options.retries);
 
-		AWS.config.update(pick(this.options, ['region', 'accessKeyId', 'secretAccessKey', 'sessionToken']));
+		AWS.config.update(pick(this.options, [
+			'region',
+			'accessKeyId',
+			'secretAccessKey',
+			'sessionToken',
+			'maxRetries',
+			'retryDelayOptions'
+		]));
 
 		if (this.options.local) {
 			// Starts dynamodb in local mode

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -34,6 +34,13 @@ test('connect options', t => {
 	});
 });
 
+test('connect with native retry options', t => {
+	db.connect({maxRetries: 5, retryDelayOptions: {base: 500}});
+
+	t.is(db.raw?.config.maxRetries, 5);
+	t.deepEqual(db.raw?.config.retryDelayOptions, {base: 500});
+});
+
 test('connect locally', t => {
 	db.connect({local: true});
 	t.is((db.raw!).endpoint.href, 'http://localhost:8000/');


### PR DESCRIPTION
Retries for methods were added back in #70 but since then the AWS SDK introduced its own retry behavior. This PR updates the logic to allow setting the latter as an alternative to that custom retry logic.

Docs and tests were updated.

It is worth noting that the custom retry logic was not disabled or modified in any way to keep full backwards compatibility. This decision may be revisited, of course.